### PR TITLE
HOTT-3167: Enable system account to write reports

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -7,6 +7,7 @@ locals {
   ]
 
   service_account_s3_policies = [
+    "reporting",
     "search-configuration",
     "opensearch-package",
   ]


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3167

### What?

I have added/removed/altered:

- [x] Added permissions for the system account to be able to write reports

### Why?

I am doing this because:

- This is needed since the backend workers now write to this bucket as part of their daily ETL job
