### PR TITLE
BAU: Fix CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ configured before you can do so.
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_reporting_certificate"></a> [reporting\_certificate](#module\_reporting\_certificate) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/acm | aws/cloudfront-v1.0.1 |
 
 ## Resources
 
@@ -77,12 +79,14 @@ No modules.
 | [aws_route53_record.trade_tariff_reporting](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_policy.cloudfront](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_ses_domain_identity.tariff_domain](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/ses_domain_identity) | resource |
 | [aws_ses_domain_identity_verification.tariff_domain_verification](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/ses_domain_identity_verification) | resource |
 | [aws_ses_email_identity.notify_email](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/resources/ses_email_identity) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecr](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.es](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_database_backups_read_policy](https://registry.terraform.io/providers/hashicorp/aws/4.61.0/docs/data-sources/iam_policy_document) | data source |
@@ -101,6 +105,7 @@ No modules.
 | <a name="input_docker_repositories"></a> [docker\_repositories](#input\_docker\_repositories) | List of repositories to create. | `list(string)` | <pre>[<br>  "tariff-backend",<br>  "tariff-frontend",<br>  "tariff-dutycalculator",<br>  "tariff-admin",<br>  "tariff-search-query-parser",<br>  "signon"<br>]</pre> | no |
 | <a name="input_google_site_verification"></a> [google\_site\_verification](#input\_google\_site\_verification) | Google site verification TXT record value. | `string` | n/a | yes |
 | <a name="input_notification_email"></a> [notification\_email](#input\_notification\_email) | Email address to send worker reports from. | `string` | `"trade-tariff-support@enginegroup.com"` | no |
+| <a name="input_s3_origin_id"></a> [s3\_origin\_id](#input\_s3\_origin\_id) | n/a | `string` | `"trade_tariff_reporting_origin"` | no |
 | <a name="input_trade_tariff_reporting"></a> [trade\_tariff\_reporting](#input\_trade\_tariff\_reporting) | n/a | `string` | `"reporting.trade-tariff.service.gov.uk"` | no |
 | <a name="input_waf_name"></a> [waf\_name](#input\_waf\_name) | n/a | `string` | `"tariff-waf-production"` | no |
 

--- a/cloudfront-tariff-reporting.tf
+++ b/cloudfront-tariff-reporting.tf
@@ -11,10 +11,10 @@ resource "aws_cloudfront_origin_access_identity" "trade_tariff_reporting_identit
 resource "aws_cloudfront_distribution" "s3_distribution_trade_tariff_reporting" {
   origin {
     domain_name = aws_s3_bucket.this["reporting"].bucket_regional_domain_name
-    origin_id   = aws_cloudfront_origin_access_identity.trade_tariff_reporting_identity.cloudfront_access_identity_path
+    origin_id   = var.s3_origin_id
 
     s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.trade_tariff_reporting_identity.id
+      origin_access_identity = aws_cloudfront_origin_access_identity.trade_tariff_reporting_identity.cloudfront_access_identity_path
     }
   }
 
@@ -23,7 +23,7 @@ resource "aws_cloudfront_distribution" "s3_distribution_trade_tariff_reporting" 
   comment         = "Trade Tariff Reporting CDN"
   aliases         = ["reporting.trade-tariff.service.gov.uk"]
   price_class     = "PriceClass_100"
-  web_acl_id      = data.aws_wafv2_web_acl.this.id
+  web_acl_id      = data.aws_wafv2_web_acl.this.arn
 
 
   default_cache_behavior {
@@ -46,9 +46,9 @@ resource "aws_cloudfront_distribution" "s3_distribution_trade_tariff_reporting" 
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
-    minimum_protocol_version       = "TLSv1.2_2021"
-    ssl_support_method             = "sni-only"
+    acm_certificate_arn      = module.reporting_certificate.aws_acm_certificate_arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
   }
 
   restrictions {
@@ -57,9 +57,35 @@ resource "aws_cloudfront_distribution" "s3_distribution_trade_tariff_reporting" 
     }
   }
 
+  depends_on = [
+    module.reporting_certificate.aws_acm_certificate_arn
+  ]
+
   lifecycle {
     ignore_changes = [origin]
   }
-
 }
 
+module "reporting_certificate" {
+  source          = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/acm?ref=aws/cloudfront-v1.0.1"
+  domain_name     = "reporting.${local.base_url}"
+  route53_zone_id = data.aws_route53_zone.selected.id
+}
+
+resource "aws_s3_bucket_policy" "cloudfront" {
+  bucket = aws_s3_bucket.this["reporting"].id
+  policy = data.aws_iam_policy_document.bucket_policy.json
+}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.this["reporting"].arn}/*"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        aws_cloudfront_origin_access_identity.trade_tariff_reporting_identity.iam_arn
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added certificate for the subdomain we are using
- Switched to using the ARN for the WAF reference
- Added bucket policy so that the Cloudfront OAI can access files in the bucket

### Why?

I am doing this because:

- We need a cert for the subdomain
- The bucket needs to be able to be reached by the OAI
