### PR TITLE
HOTT-3139: Adds permissions to list objects in reporting bucket

### DIFF
--- a/cloudfront-tariff-reporting.tf
+++ b/cloudfront-tariff-reporting.tf
@@ -79,8 +79,14 @@ resource "aws_s3_bucket_policy" "cloudfront" {
 
 data "aws_iam_policy_document" "bucket_policy" {
   statement {
-    actions   = ["s3:GetObject"]
-    resources = ["${aws_s3_bucket.this["reporting"].arn}/*"]
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      "${aws_s3_bucket.this["reporting"].arn}/*",
+      aws_s3_bucket.this["reporting"].arn
+    ]
     principals {
       type = "AWS"
       identifiers = [


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3198

### What?

I have added/removed/altered:

- [x] Added permission to list reporting objects

### Why?

I am doing this because:

- This enables a simple file explorer to list objects without changing the ACL/public access rights of the s3 bucket
