### PR TITLE
BAU: Set default root object

### DIFF
--- a/cloudfront-tariff-reporting.tf
+++ b/cloudfront-tariff-reporting.tf
@@ -18,12 +18,13 @@ resource "aws_cloudfront_distribution" "s3_distribution_trade_tariff_reporting" 
     }
   }
 
-  enabled         = true
-  is_ipv6_enabled = true
-  comment         = "Trade Tariff Reporting CDN"
-  aliases         = ["reporting.trade-tariff.service.gov.uk"]
-  price_class     = "PriceClass_100"
-  web_acl_id      = data.aws_wafv2_web_acl.this.arn
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  comment             = "Trade Tariff Reporting CDN"
+  aliases             = ["reporting.trade-tariff.service.gov.uk"]
+  price_class         = "PriceClass_100"
+  web_acl_id          = data.aws_wafv2_web_acl.this.arn
 
 
   default_cache_behavior {


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Set the CloudFront distribution's `default_root_object` to `index.html`

### Why?

I am doing this because:

- Will has created a nice file tree structure, but to access it you have to explicitly hit `reporting.trade-tariff.service.gov.uk/index.html`, which is goofy.
- Currently, hitting the root gives you a nasty XML document which your browser will turn into sludge.
- By setting the default root object, hitting the root `/` will return `index.html` instead of the user having to do it. Overall, this is nicer UX.
